### PR TITLE
fix(client): useSetNavigation default value로 돌려두는 작업을 useSetNavigation 훅 자체에게 위임

### DIFF
--- a/apps/client/hooks/useSetNavigation.ts
+++ b/apps/client/hooks/useSetNavigation.ts
@@ -12,6 +12,13 @@ const useSetNavigation = (
 
   useEffect(() => {
     setter(props);
+
+    return () => {
+      setter({
+        top: undefined,
+        bottom: false
+      });
+    };
   }, [props, setter]);
 };
 

--- a/apps/client/pages/index.page.tsx
+++ b/apps/client/pages/index.page.tsx
@@ -5,10 +5,8 @@ import { FilledButton } from "~/components/Common";
 import { Text } from "~/components/Common/Typo";
 import { OrangeSection } from "~/components/Section";
 import { env } from "~/constants";
-import { useSetNavigation } from "~/hooks";
 
 const Onboarding = () => {
-  useSetNavigation();
   const { colors, weighs } = useTheme();
   const router = useRouter();
 
@@ -26,18 +24,10 @@ const Onboarding = () => {
             ${gutter({ space: 6, direction: "horizontal" })}
           `}
         >
-          <Text
-            _fontSize={25}
-            _color={colors.white}
-            weight={weighs.medium}
-          >
+          <Text _fontSize={25} _color={colors.white} weight={weighs.medium}>
             Do you want to
           </Text>
-          <Text
-            _fontSize={25}
-            _color={colors.white}
-            weight={weighs.extraBold}
-          >
+          <Text _fontSize={25} _color={colors.white} weight={weighs.extraBold}>
             JOIN
           </Text>
         </Flex>

--- a/apps/client/pages/post/post.hooks.tsx
+++ b/apps/client/pages/post/post.hooks.tsx
@@ -1,3 +1,4 @@
+import { usePostUploadSetter, useRestaurantSetter } from "@atoms/index";
 import { useTheme } from "@emotion/react";
 import { Edit } from "@svgs/common";
 import { Flex, Spacing } from "@toss/emotion-utils";
@@ -5,7 +6,6 @@ import Image from "next/image";
 import { useCallback } from "react";
 import { Text } from "~/components/Common/Typo";
 import { useInternalRouter, useSetNavigation } from "~/hooks";
-import { usePostUploadSetter, useRestaurantSetter } from "@atoms/index";
 import { useFetchLikePercent, useFetchRestaurant } from "~/server/restaurant";
 import { useFetchReviews } from "~/server/review";
 import { countryToSvg } from "~/utils";


### PR DESCRIPTION

# Describe your changes

- useSetNavigation default value로 돌려두는 작업을 useSetNavigation 훅 자체에게 위임 

과거에는 bottomNavigation이 존재하는 페이지에서 존재하지 않는 페이지로 이동할때
존재하지 않는 페이지에서 명령적으로 useSetNavigation({bottom:false})를 해줬습니다.
하지만 확장성을 고려하면 어디서 페이지가 이동되어서 나의 페이지에 올지 모르기 때문에

useSetNavigation 훅 자체에서 언마운트시에 네비게이션 옵션을 Default value로 초기화 시켜주도록 설계했습니다.

## Issue ticket number and link (optional)

## Checklist

- [x] 🤔 이 프로젝트의 스타일 가이드를 따르나요?
- [x] 🤔 머지하기 전에 스스로 코드에 문제가 없음을 확인했나요?
- [ x] 🤔 필요한 주석을 필요한 곳에 넣어주었나요?
- [x] ⛔️ (필수) base 브랜치를 pull 받았나요?!

## Next Step Todo (optional)

## Questions

- 💬 질문 사항이에요!
- 🤷‍♂️ 확인 받고 싶은 부분이에요!
- 🔥 이건 꼭 확인해주세요!

IOS 테스트 하기 위해 리뷰 전에 머지합니다. 리뷰남겨주세용!
