### PR TITLE
feat(admin): 음식점과 리뷰가 리젝된것이라면 리젝된 이유를 default로 설정해줍니다

### DIFF
--- a/apps/admin/@types/restaurant.d.ts
+++ b/apps/admin/@types/restaurant.d.ts
@@ -21,5 +21,6 @@ declare module Restaurant {
 
   interface DetailDTO extends BaseDTO {
     images: string[];
+    cause?: string;
   }
 }

--- a/apps/admin/@types/review.d.ts
+++ b/apps/admin/@types/review.d.ts
@@ -18,5 +18,6 @@ declare module Review {
   interface DetailDTO extends BaseDTO {
     images: string[];
     userProfile: string;
+    cause?: string;
   }
 }

--- a/apps/admin/components/Posts/PostDetail/PostDetail.hooks.ts
+++ b/apps/admin/components/Posts/PostDetail/PostDetail.hooks.ts
@@ -1,3 +1,4 @@
+import { useRouter } from "next/router";
 import {
   type ChangeEvent,
   type Dispatch,
@@ -5,11 +6,13 @@ import {
   useState
 } from "react";
 import { useToast } from "~/hooks";
-import { useUpdatePublication } from "~/server/restaurant";
+import { useFetchRestaurant, useUpdatePublication } from "~/server/restaurant";
 
 const useOnEventHandler = (id: number) => {
   const toast = useToast();
-  const [rejectCause, setRejectCause] = useState("");
+  const { query } = useRouter();
+  const { data: restaurant } = useFetchRestaurant(Number(query.id));
+  const [rejectCause, setRejectCause] = useState(restaurant.cause ?? "");
 
   const { verifyRejectCause, onChangeRejectCauseHandler } = useRejectCause({
     rejectCause,

--- a/apps/admin/components/Reviews/ReviewDetail/ReviewDetail.hooks.ts
+++ b/apps/admin/components/Reviews/ReviewDetail/ReviewDetail.hooks.ts
@@ -1,3 +1,4 @@
+import { useRouter } from "next/router";
 import {
   type ChangeEvent,
   type Dispatch,
@@ -5,11 +6,13 @@ import {
   useState
 } from "react";
 import { useToast } from "~/hooks";
-import { useUpdatePublication } from "~/server/review";
+import { useFetchReview, useUpdatePublication } from "~/server/review";
 
 const useOnEventHandler = (id: number) => {
   const toast = useToast();
-  const [rejectCause, setRejectCause] = useState("");
+  const { query } = useRouter();
+  const { data: review } = useFetchReview(Number(query.id));
+  const [rejectCause, setRejectCause] = useState(review.cause ?? "");
 
   const { verifyRejectCause, onChangeRejectCauseHandler } = useRejectCause({
     rejectCause,


### PR DESCRIPTION
# Describe your changes

- 음식점과 리뷰가 리젝된것이라면 리젝된 이유를 default로 설정해줍니다


## Test method (상대방이 이 PR을 테스트할 수 있는 방법을 설명해주세요!)

- http://127.0.0.1:3000/review/157 로 들어갔을때 부적절한 설명이 자동으로 설정되어있으면 성공
- http://127.0.0.1:3000/restaurant/65 로 들어갔을때 설정되어있지 않은 이유는 

>리젝 사유 추가했습니다! N 인데 리젝 사유가 같이 안올 경우가 좀 있는데 리젝된 게시물이지만 리젝사유가 같이 등록되지 않은 데이터들이 좀 있어서 그냥 넘어가면 될 것 같습니다~

라고 해주셨습니다.

## Checklist

- [x] 🤔 이 프로젝트의 스타일 가이드를 따르나요?
- [x] 🤔 머지하기 전에 스스로 코드에 문제가 없음을 확인했나요?
- [x] 🤔 필요한 주석을 필요한 곳에 넣어주었나요?
- [x] ⛔️ (필수) base 브랜치를 pull 받았나요?!

## Next Step Todo (optional)

## Questions

- 💬 질문 사항이에요!
- 🤷‍♂️ 확인 받고 싶은 부분이에요!
- 🔥 이건 꼭 확인해주세요!

https://github.com/toppingskorea/toppings-server/issues/34 에서 백엔드분이 해결해주셨습니다.