### PR TITLE
fix(client): 유저가 고른 eating habit이 서버에 없다면 not selected를 보여줍니다

### DIFF
--- a/apps/client/components/Profile/ProfileEditPage/UserInfo/index.tsx
+++ b/apps/client/components/Profile/ProfileEditPage/UserInfo/index.tsx
@@ -25,6 +25,9 @@ const UserInfo = () => {
 
       return edit.habits && edit.habits[0].content;
     }
+
+    if (!userInfo?.habits) return "Not Selected";
+
     return userInfo?.habits && userInfo?.habits[0].content;
   }, [isProfileEatingHabitChanged, userInfo?.habits, edit.habits]);
 


### PR DESCRIPTION
# Describe your changes

유저가 고른 eating habit이 서버에 없다면 not selected를 보여줍니다

## Test method (상대방이 이 PR을 테스트할 수 있는 방법을 설명해주세요!)

실제로 eating habit을 없앤다음에(서버에 반영까지 한뒤)
profile/edit페이지에서 새로고침했을때 eating habit 인풋이 빈 값이 아닌, not selected가 나오면 성공입니다.
