### PR TITLE
fix(client): topnavigator의 가운데 요소가 전체 너비를 차지하여 양쪽 버튼들의 클릭을 방해하던것을 해결합니다

### DIFF
--- a/apps/client/components/Layout/TopNavigator/index.tsx
+++ b/apps/client/components/Layout/TopNavigator/index.tsx
@@ -78,11 +78,12 @@ const TopNavigator = () => {
               variants={defaultSlideFadeInVariants("bottom")}
               {...framerMocker}
               css={css`
+                width: fit-content;
+                margin: -10px auto 0;
                 ${flex({
                   justify: "center",
                   align: "center"
                 })}
-                margin-top: -10px;
               `}
             >
               {state.top?.title}


### PR DESCRIPTION
# Describe your changes

#143 @minsoo-web thank you!

topnavigator의 가운데 요소가 전체 너비를 차지하여 양쪽 버튼들의 클릭을 방해하던것을 해결합니다

## Test method (상대방이 이 PR을 테스트할 수 있는 방법을 설명해주세요!)

프로필 페이지 및 여러 topnavigator가 있는 페이지에서 아이콘 아래부분에 마우스를 올려봅니다.

## ASIS

<img width="289" alt="image" src="https://user-images.githubusercontent.com/69495129/220367098-c5d68d44-20f0-47bb-9d26-339fa87571de.png">


## TOBE


<img width="287" alt="image" src="https://user-images.githubusercontent.com/69495129/220367058-78257fb2-6754-4ed7-a02c-24f65bbd464e.png">
