### PR TITLE
fix(client): profile 페이지 진입시 bottomnavigation이 깜빡거리는 현상을 해결합니다.

### DIFF
--- a/apps/client/components/Profile/ProfilePage/index.tsx
+++ b/apps/client/components/Profile/ProfilePage/index.tsx
@@ -1,50 +1,74 @@
 import { css } from "@emotion/react";
 import { Suspense } from "@suspensive/react";
+import { Hamburger } from "@svgs/common";
 import { padding, Stack } from "@toss/emotion-utils";
 import Skeleton from "~/components/Skeleton";
+import { useInternalRouter, useSetNavigation } from "~/hooks";
 import { generateComponent } from "~/utils";
 import EditButton from "./EditButton";
 import Info from "./Info";
 
-const ProfilePage = () => (
-  <section
-    css={css`
-      ${padding({ x: 25 })}
-    `}
-  >
-    <Suspense.CSROnly
-      fallback={
-        <Stack.Vertical
-          css={css`
-            padding-top: 140px;
-          `}
-        >
-          <Stack.Horizontal align="center">
-            <Skeleton.Circle size={78} />
+const ProfilePage = () => {
+  const { push } = useInternalRouter();
+  useSetNavigation({
+    top: {
+      right: {
+        element: <Hamburger />,
+        onClick: () => push("/profile/menu")
+      },
+      title: (
+        <Skeleton.Box
+          size={{
+            width: 60,
+            height: 20
+          }}
+        />
+      ),
+      marginBottom: 33
+    },
+    bottom: true
+  });
 
-            <Stack.Horizontal>
-              {generateComponent(
-                <Skeleton.Box
-                  size={{
-                    width: 50,
-                    height: 50
-                  }}
-                />,
-                3
-              )}
-            </Stack.Horizontal>
-          </Stack.Horizontal>
-
-          <Stack.Vertical>
-            {generateComponent(<Skeleton.Paragraph />, 2)}
-          </Stack.Vertical>
-        </Stack.Vertical>
-      }
+  return (
+    <section
+      css={css`
+        ${padding({ x: 25 })}
+      `}
     >
-      <Info />
-    </Suspense.CSROnly>
+      <Suspense.CSROnly
+        fallback={
+          <Stack.Vertical
+            css={css`
+              padding-top: 140px;
+            `}
+          >
+            <Stack.Horizontal align="center">
+              <Skeleton.Circle size={78} />
 
-    <EditButton />
-  </section>
-);
+              <Stack.Horizontal>
+                {generateComponent(
+                  <Skeleton.Box
+                    size={{
+                      width: 50,
+                      height: 50
+                    }}
+                  />,
+                  3
+                )}
+              </Stack.Horizontal>
+            </Stack.Horizontal>
+
+            <Stack.Vertical>
+              {generateComponent(<Skeleton.Paragraph />, 2)}
+            </Stack.Vertical>
+          </Stack.Vertical>
+        }
+      >
+        <Info />
+      </Suspense.CSROnly>
+
+      <EditButton />
+    </section>
+  );
+};
 export default ProfilePage;


### PR DESCRIPTION
# Describe your changes

#141  thanks @minsoo-web

Suspense가 작동하기 전에 (데이터 패칭전에) 유저 정보가 필요하지 않은 영역을 그립니다.
title 부분빼고 아이콘이나, bottonNavigation부분은 유저 정보가 필요없기때문에 페이지 레벨에서 미리 그립니다.
그 후 데이터 패칭에 성공하면 내부 컴포넌트에서 다시 useSetNavigation을 진행합니다



## Test method (상대방이 이 PR을 테스트할 수 있는 방법을 설명해주세요!)

- profile 페이지에서 강제 새로고침을했을때 bottomNavigation이 처음부터 있어야합니다.
- map 페이지에서 강제 새로고침 후 profile 페이지로 이동했을때 bottomnavigation이 깜빡거리면 안됩니다.
