### PR TITLE
fix(client): 유저 이름에 정규식을 추가합니다.

### DIFF
--- a/apps/client/components/Profile/ProfileEditPage/RegisterButton/RegisterButton.hooks.tsx
+++ b/apps/client/components/Profile/ProfileEditPage/RegisterButton/RegisterButton.hooks.tsx
@@ -1,0 +1,86 @@
+import { useEditValue, useProfileEatingHabitChangedValue } from "@atoms/edit";
+import { useOverlay } from "@toss/use-overlay";
+import { useCallback, useMemo } from "react";
+import { AlertModal, SuccessModal } from "~/components/Common";
+import { useInternalRouter } from "~/hooks";
+import { useFetchUserInfo, useUpdateUserInfo } from "~/server/profile";
+import { replaceSpace } from "~/utils";
+
+// eslint-disable-next-line import/prefer-default-export
+export const useRegisterButtonClick = () => {
+  const { push } = useInternalRouter();
+  const { data: userInfo } = useFetchUserInfo();
+  const edit = useEditValue();
+  const overlay = useOverlay();
+
+  const { mutate: updateUserInfoMutate, isLoading: updateUserInfoIsLoading } =
+    useUpdateUserInfo({
+      onSuccess: () => {
+        overlay.open(() => <SuccessModal />);
+
+        setTimeout(() => {
+          push("/profile");
+        }, 2000);
+      }
+    });
+
+  const isProfileEatingHabitChanged = useProfileEatingHabitChangedValue();
+  const newHabits = useMemo(() => {
+    if (isProfileEatingHabitChanged) {
+      if (edit.habits?.length === 0) return [];
+
+      if (edit.habits)
+        return [
+          {
+            title: edit.habits[0].title,
+            content: replaceSpace(edit.habits[0].content)
+          }
+        ];
+    }
+
+    if (userInfo?.habits)
+      return [
+        {
+          title: userInfo.habits[0].title,
+          content: replaceSpace(userInfo.habits[0].content)
+        }
+      ];
+
+    return undefined;
+  }, [isProfileEatingHabitChanged, userInfo?.habits, edit.habits]);
+  const onClickRegisterHandler = useCallback(() => {
+    if (!userInfo) return;
+
+    const name = edit.name ?? userInfo.name;
+
+    if (!isValidateName(name)) {
+      overlay.open(({ exit }) => (
+        <AlertModal exitFn={exit} information="Invalid username" />
+      ));
+      return;
+    }
+
+    updateUserInfoMutate({
+      name,
+      country: edit.country ?? userInfo.country,
+      habits: newHabits ?? [],
+      profile: edit.profile ?? userInfo.profile
+    });
+  }, [
+    userInfo,
+    edit.name,
+    edit.country,
+    edit.profile,
+    updateUserInfoMutate,
+    newHabits,
+    overlay
+  ]);
+
+  return {
+    onClickRegisterHandler,
+    updateUserInfoIsLoading
+  };
+};
+
+const isValidateName = (name: string) =>
+  /^[A-Za-z0-9ㄱ-ㅎ|ㅏ-ㅣ|가-힣]{6,20}$/.test(name);

--- a/apps/client/components/Profile/ProfileEditPage/RegisterButton/index.tsx
+++ b/apps/client/components/Profile/ProfileEditPage/RegisterButton/index.tsx
@@ -1,76 +1,15 @@
-import { useEditValue, useProfileEatingHabitChangedValue } from "@atoms/index";
 import { css, useTheme } from "@emotion/react";
 import { Flex, padding } from "@toss/emotion-utils";
-import { useOverlay } from "@toss/use-overlay";
-import { useCallback, useMemo } from "react";
-import { FilledButton, Seek, SuccessModal } from "~/components/Common";
+import { FilledButton, Seek } from "~/components/Common";
 import { Text } from "~/components/Common/Typo";
-import { useInternalRouter } from "~/hooks";
-import { useFetchUserInfo, useUpdateUserInfo } from "~/server/profile";
-import { replaceSpace } from "~/utils";
+import { useRegisterButtonClick } from "./RegisterButton.hooks";
 
 const RegisterButton = () => {
   const { colors, weighs } = useTheme();
-  const { push } = useInternalRouter();
 
-  const { data: userInfo } = useFetchUserInfo();
-  const edit = useEditValue();
-  const overlay = useOverlay();
+  const { onClickRegisterHandler, updateUserInfoIsLoading } =
+    useRegisterButtonClick();
 
-  const { mutate: updateUserInfoMutate, isLoading: updateUserInfoIsLoading } =
-    useUpdateUserInfo({
-      onSuccess: () => {
-        overlay.open(() => <SuccessModal />);
-
-        setTimeout(() => {
-          push("/profile");
-        }, 2000);
-      }
-    });
-
-  const isProfileEatingHabitChanged = useProfileEatingHabitChangedValue();
-
-  const newHabits = useMemo(() => {
-    if (isProfileEatingHabitChanged) {
-      if (edit.habits?.length === 0) return [];
-
-      if (edit.habits)
-        return [
-          {
-            title: edit.habits[0].title,
-            content: replaceSpace(edit.habits[0].content)
-          }
-        ];
-    }
-
-    if (userInfo?.habits)
-      return [
-        {
-          title: userInfo.habits[0].title,
-          content: replaceSpace(userInfo.habits[0].content)
-        }
-      ];
-
-    return undefined;
-  }, [isProfileEatingHabitChanged, userInfo?.habits, edit.habits]);
-
-  const onClickRegisterHandler = useCallback(() => {
-    if (!userInfo) return;
-
-    updateUserInfoMutate({
-      name: edit.name ?? userInfo.name,
-      country: edit.country ?? userInfo.country,
-      habits: newHabits,
-      profile: edit.profile ?? userInfo.profile
-    });
-  }, [
-    userInfo,
-    updateUserInfoMutate,
-    edit.name,
-    edit.country,
-    edit.profile,
-    newHabits
-  ]);
   return (
     <Flex
       justify="center"

--- a/apps/client/components/Profile/ProfileEditPage/UserInfo/index.tsx
+++ b/apps/client/components/Profile/ProfileEditPage/UserInfo/index.tsx
@@ -58,7 +58,8 @@ const UserInfo = () => {
                   transform: translate3d(0,100%,0);
                 `}
               >
-                Enter only english letters (a-z) and numbers within 6-20
+                Enter only english or korean letters (a-z) and numbers within
+                6-20
                 {"\n"}characters for the user name.
               </Text>
             }


### PR DESCRIPTION
# Describe your changes

#144 thx @minsoo-web

기존에는 안내문구만  Enter only english or korean letters (a-z) and numbers within 6-20 characters for the user name.
라고 되어있었지만, 실제 정규식이 작동하지 않아서 특수문자도 가능한 상태였습니다. 그러므로 정규식을 추가합니다.

## Test method (상대방이 이 PR을 테스트할 수 있는 방법을 설명해주세요!)
실제 올바르지 않은 이름을 작성한 뒤, register버튼을 눌러봅니다