### PR TITLE
Feat(client) : 맵의 거리 조절을 고정합니다.

### DIFF
--- a/apps/client/components/Map/MapPage/MapPage.hooks.ts
+++ b/apps/client/components/Map/MapPage/MapPage.hooks.ts
@@ -6,6 +6,7 @@ import {
   useCurrentPositionLoadingValue,
   useCurrentSelectCategoryValue,
   useCurrentSelectKeywordValue,
+  useCurrentZoomLevelAtomState,
   useSearchByFilteringState
 } from "@atoms/index";
 import { useTheme } from "@emotion/react";
@@ -38,6 +39,8 @@ const useMap = () => {
     useSearchByFilteringState();
   const currentHabitTitle = useCurrentHabitTitleValue();
   const currentPositionLoading = useCurrentPositionLoadingValue();
+  const [currentZoomLevel, setCurrentZoomLevel] =
+    useCurrentZoomLevelAtomState();
 
   const mapMutateOnSuccess = useCallback(
     (data: Restaurant.SearchByFilteringDTO[]) => {
@@ -71,6 +74,7 @@ const useMap = () => {
   const mapEventHandler = (map: kakao.maps.Map) => {
     const bounds = map.getBounds() as Map.KakaoBounds;
     const getCenter = map.getCenter();
+    setCurrentZoomLevel(map.getLevel());
 
     setCurrentLocation({
       latitude: getCenter.getLat(),
@@ -111,7 +115,8 @@ const useMap = () => {
     push,
     currentPositionLoading,
     colors,
-    zIndex
+    zIndex,
+    currentZoomLevel
   };
 };
 

--- a/apps/client/components/Map/MapPage/index.tsx
+++ b/apps/client/components/Map/MapPage/index.tsx
@@ -19,7 +19,7 @@ const MapPage = () => {
       <OpenGraph title="Map" />
       <KakaoMap
         center={app.currentLocation}
-        level={5}
+        level={app.currentZoomLevel}
         maxLevel={13}
         onDragEnd={app.mapEventHandler}
         onLoaded={app.mapEventHandler}

--- a/apps/client/recoil/atoms/map.ts
+++ b/apps/client/recoil/atoms/map.ts
@@ -16,3 +16,15 @@ export const useCurrentPositionLoadingValue = () =>
   useRecoilValue(currentPositionLoadingAtom);
 export const useCurrentPositionLoadingSetter = () =>
   useSetRecoilState(currentPositionLoadingAtom);
+
+const currentZoomLevelAtom = atom<number>({
+  key: "currentZoomLevelAtom",
+  default: 5
+});
+
+export const useCurrentZoomLevelAtomState = () =>
+  useRecoilState(currentZoomLevelAtom);
+export const useCurrentZoomLevelAtomValue = () =>
+  useRecoilValue(currentZoomLevelAtom);
+export const useCurrentZoomLevelAtomSetter = () =>
+  useSetRecoilState(currentZoomLevelAtom);


### PR DESCRIPTION
# Describe your changes

- 지도의 거리 조절 값을 고정시켜 내가 줌을 한 후에 식당을 들른 뒤에 다시 지도로 돌아와도 지도의 거리가 초기화되지 않습니다.

## Test method (상대방이 이 PR을 테스트할 수 있는 방법을 설명해주세요!)

- 127.0.0.1:3000/map 에서 거리를 조절하신 후에 식당을 눌러 들어가신 후에 다시 되돌아와보세요!