### PR TITLE
fix: 리뷰 상세 페이지에서 프로필 사진의 objectfit을 수정합니다.

### DIFF
--- a/apps/client/components/Review/ReviewDetailPage/UserInfoRow/index.tsx
+++ b/apps/client/components/Review/ReviewDetailPage/UserInfoRow/index.tsx
@@ -29,6 +29,7 @@ const UserInfoRow = () => {
             width={32}
             height={32}
             css={css`
+              object-fit: cover;
               border-radius: 50%;
             `}
           />


### PR DESCRIPTION
# Describe your changes

리뷰 상세 페이지에서 프로필사진이 깨지는 문제가 있어서 object-fit 옵션을 cover로 부여합니다.

## Test method (상대방이 이 PR을 테스트할 수 있는 방법을 설명해주세요!)

## ASIS

![image](https://user-images.githubusercontent.com/69495129/222471796-15b89b91-0f90-4580-82aa-476147f6e851.png)

## TOBE

![image](https://user-images.githubusercontent.com/69495129/222471958-3f9aed1c-6d10-4e57-b138-5daa6ae9397b.png)
