### PR TITLE
feat(client) : queryChunk에서 사용되던 deprecated method인 substr을 substring으로 변경

### DIFF
--- a/apps/client/utils/common/queryChunk.ts
+++ b/apps/client/utils/common/queryChunk.ts
@@ -10,5 +10,5 @@ export const queryChunk = (str: string, query: string) => {
     return str; // bail early
   }
   const l = q.length;
-  return [str.substr(0, x), str.substr(x, l), str.substr(x + l)];
+  return [str.substring(0, x), str.substring(x, l + 1), str.substring(x + l)];
 };

--- a/apps/client/utils/common/queryChunk.ts
+++ b/apps/client/utils/common/queryChunk.ts
@@ -10,5 +10,6 @@ export const queryChunk = (str: string, query: string) => {
     return str; // bail early
   }
   const l = q.length;
-  return [str.substring(0, x), str.substring(x, l + 1), str.substring(x + l)];
+
+  return [str.substring(0, x), str.substring(x, x + l), str.substring(x + l)];
 };


### PR DESCRIPTION
# Describe your changes

- Deprecated (중요도가 떨어져 더 이상 사용되지 않고 앞으로는 사라지게 될)
<img width="771" alt="image" src="https://user-images.githubusercontent.com/55759551/222760582-bdb1c8ba-a4db-4f41-ab30-b07d37ae5461.png">

substr을 substring으로 변경하였습니다.

## Test method (상대방이 이 PR을 테스트할 수 있는 방법을 설명해주세요!)

- http://localhost:3000/search/restaurant 에서 레스토랑 검색이 잘 되는 지 확인합니다.
