### PR TITLE
fix(client): map 페이지에서 위도 경도를 불러오기 전에 0을 랜더링하는 이슈를 해결합니다.

### DIFF
--- a/apps/client/components/Map/MapPage/index.tsx
+++ b/apps/client/components/Map/MapPage/index.tsx
@@ -129,26 +129,26 @@ const MapPage = () => {
         )}
 
         {app.fixedCurrentLocation.latitude &&
-          app.fixedCurrentLocation.longitude && (
-            <MapMarker
-              position={{
-                latitude: app.fixedCurrentLocation.latitude,
-                longitude: app.fixedCurrentLocation.longitude
-              }}
-            >
-              <Lottie
-                loop
-                autoPlay
-                animationData={myLocation}
-                css={css`
-                  ${size({
-                    width: 30,
-                    height: 30
-                  })}
-                `}
-              />
-            </MapMarker>
-          )}
+        app.fixedCurrentLocation.longitude ? (
+          <MapMarker
+            position={{
+              latitude: app.fixedCurrentLocation.latitude,
+              longitude: app.fixedCurrentLocation.longitude
+            }}
+          >
+            <Lottie
+              loop
+              autoPlay
+              animationData={myLocation}
+              css={css`
+                ${size({
+                  width: 30,
+                  height: 30
+                })}
+              `}
+            />
+          </MapMarker>
+        ) : null}
       </KakaoMap>
     </>
   );


### PR DESCRIPTION
# Describe your changes

[버그 리포트](https://toppings-workspace.slack.com/archives/C04R7LNKTST/p1678535755176759)
맵 페이지를 입장할때 좌상단에 0 이라는 숫자가 랜더링되는 오류가 있습니다

## Test method (상대방이 이 PR을 테스트할 수 있는 방법을 설명해주세요!)

맵에서 강제 새로고침했을때 좌측 상단에 0 숫자가 안보이는지 확인합니다
