### PR TITLE
refactor(client): layout 폴더들 내부 컴포넌트의 css로 처리했던 부분을 styles파일로 분리합니다.

### DIFF
--- a/apps/client/components/Layout/BottomNavigator/BottomNavigator.hooks.tsx
+++ b/apps/client/components/Layout/BottomNavigator/BottomNavigator.hooks.tsx
@@ -3,7 +3,7 @@ import { usePostUploadReset } from "@atoms/post";
 import type { EmotionJSX } from "@emotion/react/types/jsx-namespace";
 import type { ReactNode } from "react";
 import { useResetProfileEditPageState } from "~/components/Profile/ProfileEditPage/ProfileEditPage.hooks";
-import { useInternalRouter } from "~/hooks";
+import { useInternalRouter, useProtectRouteModal } from "~/hooks";
 import { usePostSearchRestaurantStore } from "~/stores/post";
 import type navList from "./BottomNavigator.constants";
 
@@ -25,7 +25,7 @@ export const useRenderIcon = () => {
   };
 };
 
-export const useClickNavigationHandler = () => {
+const useClickNavigationHandler = () => {
   const { push } = useInternalRouter();
   const { resetProfileEditPageState } = useResetProfileEditPageState();
   const resetPostSearchRestaurant = usePostSearchRestaurantStore(
@@ -50,5 +50,20 @@ export const useClickNavigationHandler = () => {
 
   return {
     onClickNavigationHandler
+  };
+};
+
+export const useIconButtonClick = () => {
+  const { onClickNavigationHandler } = useClickNavigationHandler();
+  const { onClickProtectedButtonHandler } = useProtectRouteModal();
+
+  const onClickIconButtonHandler =
+    () => (href: Util.ElementType<typeof navList>["href"]) => {
+      if (href === "/") onClickNavigationHandler(href);
+      else onClickProtectedButtonHandler(() => onClickNavigationHandler(href));
+    };
+
+  return {
+    onClickIconButtonHandler
   };
 };

--- a/apps/client/components/Layout/BottomNavigator/BottomNavigator.styles.ts
+++ b/apps/client/components/Layout/BottomNavigator/BottomNavigator.styles.ts
@@ -1,0 +1,21 @@
+import styled from "@emotion/styled";
+import { flex, padding, width100 } from "@toss/emotion-utils";
+
+export const Container = styled.nav`
+  ${width100}
+  background-color: ${({ theme }) => theme.colors.white};
+  max-width: inherit;
+  height: ${({ theme }) => theme.dimensions.bottomNavigationHeight}px;
+  ${padding({ x: 45, top: 20 })};
+  z-index: ${({ theme }) => theme.zIndex.two};
+`;
+
+export const ListContainer = styled.ul`
+  ${flex({ justify: "space-between", align: "center" })};
+`;
+
+export const IconButton = styled.button<{ fill: string }>`
+  path {
+    fill: ${({ fill }) => fill};
+  }
+`;

--- a/apps/client/components/Layout/BottomNavigator/index.tsx
+++ b/apps/client/components/Layout/BottomNavigator/index.tsx
@@ -1,61 +1,34 @@
-import { css, useTheme } from "@emotion/react";
-import { flex, padding, width100 } from "@toss/emotion-utils";
+import { useTheme } from "@emotion/react";
 import { motion } from "framer-motion";
-import { useInternalRouter, useProtectRouteModal } from "~/hooks";
+import { useInternalRouter } from "~/hooks";
 import navList from "./BottomNavigator.constants";
-import {
-  useClickNavigationHandler,
-  useRenderIcon
-} from "./BottomNavigator.hooks";
+import { useIconButtonClick, useRenderIcon } from "./BottomNavigator.hooks";
+import { Container, IconButton, ListContainer } from "./BottomNavigator.styles";
 
 const BottomNavigator = () => {
-  const { colors, dimensions, zIndex } = useTheme();
+  const { colors } = useTheme();
   const { asPath } = useInternalRouter();
 
-  const { onClickProtectedButtonHandler } = useProtectRouteModal();
-
   const { renderIcon } = useRenderIcon();
-  const { onClickNavigationHandler } = useClickNavigationHandler();
+
+  const { onClickIconButtonHandler } = useIconButtonClick();
 
   return (
-    <nav
-      css={css`
-        ${width100}
-        background-color: ${colors.white};
-        max-width: inherit;
-        height: ${dimensions.bottomNavigationHeight}px;
-        ${padding({ x: 45, top: 20 })}
-        z-index: ${zIndex.two};
-      `}
-    >
-      <ul
-        css={css`
-          ${flex({ justify: "space-between", align: "center" })};
-        `}
-      >
+    <Container>
+      <ListContainer>
         {navList.map(({ icon, href, activatedIcon }) => (
           <motion.li key={href} whileTap={{ scale: 0.9 }}>
-            <button
+            <IconButton
               type="button"
-              onClick={() => {
-                if (href === "/") onClickNavigationHandler(href);
-                else
-                  onClickProtectedButtonHandler(() =>
-                    onClickNavigationHandler(href)
-                  );
-              }}
-              css={css`
-                path {
-                  fill: ${colors.secondary[href === asPath ? "6D" : "D9"]};
-                }
-              `}
+              onClick={onClickIconButtonHandler}
+              fill={colors.secondary[href === asPath ? "6D" : "D9"]}
             >
               {renderIcon(icon, activatedIcon, href)}
-            </button>
+            </IconButton>
           </motion.li>
         ))}
-      </ul>
-    </nav>
+      </ListContainer>
+    </Container>
   );
 };
 

--- a/apps/client/components/Layout/EmptyView/EmptyView.styles.ts
+++ b/apps/client/components/Layout/EmptyView/EmptyView.styles.ts
@@ -1,0 +1,14 @@
+import styled from "@emotion/styled";
+import { Flex, position } from "@toss/emotion-utils";
+import Image from "next/image";
+
+export const GrayLogoImage = styled(Image)`
+  margin-top: 223px;
+`;
+
+export const BottomContainer = styled(Flex)`
+  ${({ theme }) =>
+    position("fixed", {
+      bottom: theme.dimensions.bottomNavigationHeight + 104
+    })};
+`;

--- a/apps/client/components/Layout/EmptyView/index.tsx
+++ b/apps/client/components/Layout/EmptyView/index.tsx
@@ -1,9 +1,9 @@
-import { css, useTheme } from "@emotion/react";
+import { useTheme } from "@emotion/react";
 import type { EmotionJSX } from "@emotion/react/types/jsx-namespace";
 import { grayLogo } from "@images/common";
-import { Flex, position } from "@toss/emotion-utils";
-import Image from "next/image";
+import { Flex } from "@toss/emotion-utils";
 import { Text } from "~/components/Common/Typo";
+import { BottomContainer, GrayLogoImage } from "./EmptyView.styles";
 
 interface Props {
   content: string;
@@ -11,36 +11,25 @@ interface Props {
 }
 
 const EmptyView = ({ content, CTAButton }: Props) => {
-  const { colors, weighs, dimensions } = useTheme();
+  const { colors, weighs } = useTheme();
 
   return (
     <Flex.Center>
-      <Image
+      <GrayLogoImage
         src={grayLogo}
         alt="TOPPINGS"
         width={205}
         height={84}
         quality={100}
-        css={css`
-          margin-top: 223px;
-        `}
       />
 
-      <Flex
-        direction="column"
-        align="center"
-        css={css`
-          ${position("fixed", {
-            bottom: dimensions.bottomNavigationHeight + 104
-          })}
-        `}
-      >
+      <BottomContainer direction="column" align="center">
         <Text _fontSize={19} weight={weighs.bold} _color={colors.secondary[69]}>
           {content}
         </Text>
 
         {CTAButton}
-      </Flex>
+      </BottomContainer>
     </Flex.Center>
   );
 };

--- a/apps/client/components/Layout/Recent/SearchLayout/SearchLayout.styles.ts
+++ b/apps/client/components/Layout/Recent/SearchLayout/SearchLayout.styles.ts
@@ -1,0 +1,10 @@
+import styled from "@emotion/styled";
+import { padding, position, width100 } from "@toss/emotion-utils";
+
+export const Container = styled.section`
+  ${padding({ x: 16, y: 22 })};
+  ${position("fixed", { bottom: 0 })};
+  background-color: ${({ theme }) => theme.colors.white};
+  max-width: ${({ theme }) => theme.dimensions.viewWidth - 32}px;
+  ${width100}
+`;

--- a/apps/client/components/Layout/Recent/SearchLayout/index.tsx
+++ b/apps/client/components/Layout/Recent/SearchLayout/index.tsx
@@ -1,26 +1,11 @@
-import { css, useTheme } from "@emotion/react";
-import { padding, position, width100 } from "@toss/emotion-utils";
+import { Container } from "./SearchLayout.styles";
 
 interface Props {
   children: JSX.Element;
 }
 
 const SearchLayout = ({ children }: Props) => {
-  const { colors, dimensions } = useTheme();
-
-  return (
-    <div
-      css={css`
-        ${padding({ x: 16, y: 22 })};
-        ${position("fixed", { bottom: 0 })}
-        background-color: ${colors.white};
-        max-width: ${dimensions.viewWidth - 32}px;
-        ${width100}
-      `}
-    >
-      {children}
-    </div>
-  );
+  return <Container>{children}</Container>;
 };
 
 export default SearchLayout;

--- a/apps/client/components/Layout/Recent/index.ts
+++ b/apps/client/components/Layout/Recent/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as SearchLayout } from "./SearchLayout";

--- a/apps/client/components/Layout/TopNavigator/TopNavigator.styles.ts
+++ b/apps/client/components/Layout/TopNavigator/TopNavigator.styles.ts
@@ -1,0 +1,35 @@
+import styled from "@emotion/styled";
+import {
+  type CSSPixelValue,
+  flex,
+  padding,
+  position
+} from "@toss/emotion-utils";
+import { motion } from "framer-motion";
+
+export const Header = styled.header`
+  ${position("sticky", { top: 0 })};
+  z-index: ${({ theme }) => theme.zIndex.one};
+`;
+
+export const Nav = styled.nav<{ paddingBottom?: CSSPixelValue }>`
+  ${flex({ direction: "column" })};
+
+  ${({ paddingBottom = 24 }) =>
+    padding({
+      x: 28,
+      top: 31,
+      bottom: paddingBottom
+    })};
+
+  background-color: white;
+`;
+
+export const Title = styled(motion.div)`
+  width: fit-content;
+  margin: -10px auto 0;
+  ${flex({
+    justify: "center",
+    align: "center"
+  })};
+`;

--- a/apps/client/components/Layout/TopNavigator/index.tsx
+++ b/apps/client/components/Layout/TopNavigator/index.tsx
@@ -1,38 +1,21 @@
 import { useNavigationValue } from "@atoms/index";
-import { css, useTheme } from "@emotion/react";
 import { LeftArrow } from "@svgs/common";
-import { Flex, flex, padding, position, Spacing } from "@toss/emotion-utils";
-import { AnimatePresence, motion } from "framer-motion";
+import { Flex, Spacing } from "@toss/emotion-utils";
+import { AnimatePresence } from "framer-motion";
 import { MotionButton } from "~/components/Common";
 import { defaultSlideFadeInVariants, framerMocker } from "~/constants";
 import { useClickBackButton } from "./TopNavigator.hooks";
+import { Header, Nav, Title } from "./TopNavigator.styles";
 
 const TopNavigator = () => {
-  const { zIndex } = useTheme();
   const state = useNavigationValue();
 
   const { onClickBackButton } = useClickBackButton();
 
   return (
     <AnimatePresence>
-      <header
-        css={css`
-          ${position("sticky", { top: 0 })}
-          z-index: ${zIndex.one};
-        `}
-      >
-        <nav
-          css={css`
-            ${flex({ direction: "column" })}
-            ${padding({
-              x: 28,
-              top: 31,
-              bottom: state.top?.marginBottom ?? 24
-            })}
-            
-            background-color: white;
-          `}
-        >
+      <Header>
+        <Nav paddingBottom={state.top?.marginBottom}>
           {state.top?.hideBackButton && !state.top.right ? (
             <Spacing size={28} />
           ) : (
@@ -56,23 +39,15 @@ const TopNavigator = () => {
           )}
 
           {state.top?.title && (
-            <motion.div
+            <Title
               variants={defaultSlideFadeInVariants("bottom")}
               {...framerMocker}
-              css={css`
-                width: fit-content;
-                margin: -10px auto 0;
-                ${flex({
-                  justify: "center",
-                  align: "center"
-                })}
-              `}
             >
               {state.top?.title}
-            </motion.div>
+            </Title>
           )}
-        </nav>
-      </header>
+        </Nav>
+      </Header>
     </AnimatePresence>
   );
 };

--- a/apps/client/components/Onboarding/OnboardingPage/OnboardingPage.hooks.ts
+++ b/apps/client/components/Onboarding/OnboardingPage/OnboardingPage.hooks.ts
@@ -1,0 +1,16 @@
+import { useRouter } from "next/router";
+import { env } from "~/constants";
+
+export const useLoginClick = () => {
+  const router = useRouter();
+
+  const kakaoUrl = `${env.TOPPINGS_SERVER_URL}/oauth2/authorization/kakao?redirect_uri=${env.REDIRECT_URI}`;
+
+  const onLoginHandler = () => {
+    router.replace(kakaoUrl);
+  };
+
+  return {
+    onLoginHandler
+  };
+};

--- a/apps/client/components/Onboarding/OnboardingPage/OnboardingPage.styles.ts
+++ b/apps/client/components/Onboarding/OnboardingPage/OnboardingPage.styles.ts
@@ -1,0 +1,6 @@
+import styled from "@emotion/styled";
+import { Flex, gutter } from "@toss/emotion-utils";
+
+export const DescriptionContainer = styled(Flex)`
+  ${gutter({ space: 6, direction: "horizontal" })}
+`;

--- a/apps/client/components/Onboarding/OnboardingPage/index.tsx
+++ b/apps/client/components/Onboarding/OnboardingPage/index.tsx
@@ -1,32 +1,22 @@
-import { css, useTheme } from "@emotion/react";
-import { Flex, gutter } from "@toss/emotion-utils";
-import { useRouter } from "next/router";
+import { useTheme } from "@emotion/react";
 import { FilledButton } from "~/components/Common";
 import { Text } from "~/components/Common/Typo";
 import { OrangeSection } from "~/components/Section";
 import { OpenGraph } from "~/components/Util";
-import { env } from "~/constants";
+import { useLoginClick } from "./OnboardingPage.hooks";
+import { DescriptionContainer } from "./OnboardingPage.styles";
 
 const Onboarding = () => {
   const { colors, weighs } = useTheme();
-  const router = useRouter();
 
-  const kakaoUrl = `${env.TOPPINGS_SERVER_URL}/oauth2/authorization/kakao?redirect_uri=${env.REDIRECT_URI}`;
-
-  const onLoginHandler = () => {
-    router.replace(kakaoUrl);
-  };
+  const { onLoginHandler } = useLoginClick();
 
   return (
     <>
       <OpenGraph title="onboarding" />
       <OrangeSection
         description={
-          <Flex
-            css={css`
-              ${gutter({ space: 6, direction: "horizontal" })}
-            `}
-          >
+          <DescriptionContainer>
             <Text _fontSize={21} _color={colors.white} weight={weighs.medium}>
               Do you want to
             </Text>
@@ -37,7 +27,7 @@ const Onboarding = () => {
             >
               JOIN
             </Text>
-          </Flex>
+          </DescriptionContainer>
         }
         button={
           <FilledButton


### PR DESCRIPTION
# Describe your changes

css prop 특성상 코드의 Line수를 많이 차지하는 경향이 있었는데 확실히 styles로 분리하니 코드의 가독성이 좋아졌어요..
편리했는데 가독성이 안좋은 단점이 있었는데 해결되서 다행이네요.

hooks로 비즈니스 로직을 분리하고, styles로 구체적인 스타일링 코드를 분리하니 tsx코드가 한결 간결해져서 보다 명확하게 계층관계를 파악할 수 있게 된 것 같아요

styles파일 내부에서 styled.div 의 변수명을 생각하는것은 감안해야하는것 같아요..! 변수명 정할때 시간이 걸리긴하네요 ㅋㅋ😄  주로 Container, Wrapper 와 같은 변수명을 사용하면 좋을것 같아요~

동규님 말씀대로 styled 함수 내부에서는 최적화가 되어있어서 퍼포먼스상에도 좋을 수 있겠네요!

## Test method (상대방이 이 PR을 테스트할 수 있는 방법을 설명해주세요!)
