### PR TITLE
fix(clietn): profile 페이지의 스켈레톤 위치를 제대로 조정합니다, Skeleton을 사용하는 페이지를 부드럽게 보여줍니다.

### DIFF
--- a/apps/client/components/Common/PageLoader/index.tsx
+++ b/apps/client/components/Common/PageLoader/index.tsx
@@ -97,6 +97,7 @@ const PageLoader = () => {
             exit={{ opacity: 0 }}
             css={css`
               height: 100%;
+              background-color: ${colors.white};
             `}
           />
         </div>

--- a/apps/client/components/Notice/NoticePage/index.tsx
+++ b/apps/client/components/Notice/NoticePage/index.tsx
@@ -2,9 +2,11 @@ import { useTheme } from "@emotion/react";
 import { Suspense } from "@suspensive/react";
 import { Skeleton } from "@toppings/components";
 import { Stack } from "@toss/emotion-utils";
+import { motion } from "framer-motion";
 import { useEffect } from "react";
 import { Text } from "~/components/Common/Typo";
 import { OpenGraph } from "~/components/Util";
+import { fadeInVariants, framerMocker } from "~/constants";
 import { useSetNavigation } from "~/hooks";
 import { useNoticeActivateSetter } from "~/recoil/atoms/noticeActivate";
 import { generateComponent } from "~/utils";
@@ -47,7 +49,9 @@ const Notice = () => {
           </Stack.Vertical>
         }
       >
-        <NotificationList />
+        <motion.div {...framerMocker} variants={fadeInVariants(0.6)}>
+          <NotificationList />
+        </motion.div>
       </Suspense.CSROnly>
     </div>
   );

--- a/apps/client/components/Profile/ProfilePage/index.tsx
+++ b/apps/client/components/Profile/ProfilePage/index.tsx
@@ -3,6 +3,8 @@ import { Suspense } from "@suspensive/react";
 import { Hamburger } from "@svgs/common";
 import { Skeleton } from "@toppings/components";
 import { padding, Stack } from "@toss/emotion-utils";
+import { motion } from "framer-motion";
+import { fadeInVariants, framerMocker } from "~/constants";
 import { useInternalRouter, useSetNavigation } from "~/hooks";
 import { generateComponent } from "~/utils";
 import EditButton from "./EditButton";
@@ -60,7 +62,9 @@ const ProfilePage = () => {
           </Stack.Vertical>
         }
       >
-        <Info />
+        <motion.div {...framerMocker} variants={fadeInVariants(0.6)}>
+          <Info />
+        </motion.div>
       </Suspense.CSROnly>
 
       <EditButton />

--- a/apps/client/components/Profile/ProfilePage/index.tsx
+++ b/apps/client/components/Profile/ProfilePage/index.tsx
@@ -37,12 +37,8 @@ const ProfilePage = () => {
     >
       <Suspense.CSROnly
         fallback={
-          <Stack.Vertical
-            css={css`
-              padding-top: 140px;
-            `}
-          >
-            <Stack.Horizontal align="center">
+          <Stack.Vertical>
+            <Stack.Horizontal align="center" gutter={220}>
               <Skeleton.Circle size={78} />
 
               <Stack.Horizontal>

--- a/apps/client/constants/Motions.ts
+++ b/apps/client/constants/Motions.ts
@@ -29,6 +29,26 @@ export const defaultFadeInVariants: Variants = {
   }
 };
 
+export const fadeInVariants: (duration: number) => Variants = (
+  duration: number
+) => ({
+  initial: {
+    opacity: 0,
+    transition: { duration, ease: defaultEasing },
+    willChange: "opacity"
+  },
+  animate: {
+    opacity: 1,
+    transition: { duration, ease: defaultEasing },
+    willChange: "opacity"
+  },
+  exit: {
+    opacity: 0,
+    transition: { duration, ease: defaultEasing },
+    willChange: "opacity"
+  }
+});
+
 export const defaultScaleChangeVariants: Variants = {
   initial: {
     scale: 0


### PR DESCRIPTION
# Describe your changes

- 프로필 페이지의 스켈레톤 위치가 많이 실제 컴포넌트와 어긋나있어서 UX가 좋지 못했습니다. 수정완료했습니다!
- 알림페이지 / 프로필 페이지는 처음에 스켈레톤이 떳다가 실제 컴포넌트가 너무 갑자기 뜨는 이유로 UX에 좋지 않았습니다. 스켈레톤이 사라지고 나서도 부드럽게 실제 컴포넌트가 나타나도록합니다

## Test method (상대방이 이 PR을 테스트할 수 있는 방법을 설명해주세요!)

https://user-images.githubusercontent.com/69495129/225687151-7f964cdf-30ac-4604-8dad-bd527ee85ead.mov

