### PR TITLE
fix(client): 게시글 작성 취소 플로우 오류를 수정합니다.

### DIFF
--- a/apps/client/components/Post/PostAddPage/PostAddPage.hooks.tsx
+++ b/apps/client/components/Post/PostAddPage/PostAddPage.hooks.tsx
@@ -39,7 +39,11 @@ export const useSetNavigation = () => {
   const { isModifyMode } = useCheckModifyMode();
   const overlay = useOverlay();
   const { colors, weighs } = useTheme();
-  const { back } = useInternalRouter();
+  const { push } = useInternalRouter();
+
+  const onClickAlertModalRightHandler = () => {
+    push("/");
+  };
 
   useSetNavigationHook({
     top: {
@@ -53,7 +57,10 @@ export const useSetNavigation = () => {
         element: <Exit />,
         onClick: () =>
           overlay.open(({ exit }) => (
-            <AlertModal exitFn={exit} rightClick={{ fn: back, text: "sure" }} />
+            <AlertModal
+              exitFn={exit}
+              rightClick={{ fn: onClickAlertModalRightHandler, text: "sure" }}
+            />
           ))
       },
       backButtonCaution: true,


### PR DESCRIPTION
# Describe your changes

기존 작동 => 사용자가 게시글 선택에서 음식점 선택을 갔다와서 우상단의 취소버튼을 누르면 전 페이지가 음식점 선택이므로 거기 페이지로 이동함 그러므로 사용자는 게시글 작성에서 절대 빠져나올수없는 버그가 존재


우상단의 X 버튼을 누르면 전 페이지로 이동하는것이 아닌 맵 페이지로 이동시킵니다.

## Test method (상대방이 이 PR을 테스트할 수 있는 방법을 설명해주세요!)

게시글 추가 => 음식점 선택까지 진행한뒤 우상단의 X버튼을 통해서 게시글 작성을 취소해보세요! 음식점 선택페이지가 아닌 맵페이지로 이동하면 성공입니다!